### PR TITLE
Fix bugs

### DIFF
--- a/lib/apiql.rb
+++ b/lib/apiql.rb
@@ -457,9 +457,9 @@ class APIQL
         o = nil
         names.each_with_index do |field, index|
           if o.nil?
-            return unless field.to_sym.in? self.class.apiql_attributes
+            return unless field.to_sym.in? self.class.send(:apiql_attributes)
 
-            if respond_to?(field) && (methods - Object.methods).include?(name.to_sym)
+            if respond_to?(field) && (methods - Object.methods).include?(field.to_sym)
               o = public_send(field)
             else
               o = object.public_send(field)
@@ -474,7 +474,7 @@ class APIQL
             o.instance_variable_set('@eager_load', @eager_load)
             @context.inject_delegators(self)
 
-            if o.respond_to?(field) && (o.methods - Object.methods).include?(name.to_sym)
+            if o.respond_to?(field) && (o.methods - Object.methods).include?(field.to_sym)
               if index == names.count - 1
                 o = o.public_send(field, *params)
               else
@@ -491,7 +491,7 @@ class APIQL
       else
         return unless field.to_sym.in? self.class.send(:apiql_attributes)
 
-        if respond_to?(field) && (methods - Object.methods).include?(name.to_sym)
+        if respond_to?(field) && (methods - Object.methods).include?(field.to_sym)
           public_send(field, *params)
         else
           object.public_send(field, *params)


### PR DESCRIPTION
Hi Dima!
I found some errors related to v 1.0.5. Please, take a look at it.
Also, I didn't dive into it yet but there is one more issue.
Assuming the Entity has an attribute that the main model doesn't have:
 i.e. Comment.new.respond_to?(:parent) => false
 Comment::Entity.new.respond_to?(:parent) => true
  this code leads to the error:
`(methods - Object.methods).include?(name.to_sym)`
In my case, both methods and Object.methods include the 'parent' method and here
`if respond_to?(field) && (methods - Object.methods).include?(field.to_sym)
    1)          o = public_send(field)
            else
     2)         o = object.public_send(field)
            end`
here p 2) is called and it raises the 'undefined method parent for Comment'.